### PR TITLE
[FEAT] Favorite 및 ImageFile 엔티티를 위한 Repository 인터페이스 추가 #87

### DIFF
--- a/src/main/java/com/whiskey/rvcom/repository/FavoriteRepository.java
+++ b/src/main/java/com/whiskey/rvcom/repository/FavoriteRepository.java
@@ -1,0 +1,8 @@
+package com.whiskey.rvcom.repository;
+
+import com.whiskey.rvcom.entity.favorite.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite , Long> {
+
+}

--- a/src/main/java/com/whiskey/rvcom/repository/ImageFileRepository.java
+++ b/src/main/java/com/whiskey/rvcom/repository/ImageFileRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
 
-    
 }

--- a/src/main/java/com/whiskey/rvcom/repository/ImageFileRepository.java
+++ b/src/main/java/com/whiskey/rvcom/repository/ImageFileRepository.java
@@ -1,0 +1,9 @@
+package com.whiskey.rvcom.repository;
+
+import com.whiskey.rvcom.entity.resource.ImageFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+
+    
+}


### PR DESCRIPTION
## 변경 사항
- FavoriteRepository 인터페이스 추가
- ImageFileRepository 인터페이스 추가

## 설명
이 PR은 Favorite 및 ImageFile 엔티티에 대한 데이터 액세스를 위한 새로운 Repository 인터페이스를 추가합니다. 두 인터페이스 모두 JpaRepository를 확장하여 기본적인 CRUD 작업을 지원합니다.

## 추가 정보
향후 이 Repository들을 사용하는 서비스 계층 구현이 필요

# 리뷰 부탁드려요~