### PR TITLE
음식점 당 리뷰정보 페이지에 바인딩하는 컨트롤러 로직 작성

### DIFF
--- a/src/main/java/com/whiskey/rvcom/misc/TestController.java
+++ b/src/main/java/com/whiskey/rvcom/misc/TestController.java
@@ -85,10 +85,10 @@ public class TestController {
     public void adminReport() {
     }
 
-    @GetMapping("/restaurant/{restaurantId}/{tab}")
-    public String getRestaurantDetailWithTab(@PathVariable Long restaurantId, @PathVariable String tab) {
-        // TODO: restaurantId와 tab에 따른 데이터 로딩 로직 구현
-        // TODO: 모델에 restaurantId와 tab 정보 추가
-        return "restaurantDetail";
-    }
+//    @GetMapping("/restaurant/{restaurantId}/{tab}")
+//    public String getRestaurantDetailWithTab(@PathVariable Long restaurantId, @PathVariable String tab) {
+//        // TODO: restaurantId와 tab에 따른 데이터 로딩 로직 구현
+//        // TODO: 모델에 restaurantId와 tab 정보 추가
+//        return "restaurantDetail";
+//    }
 }

--- a/src/main/java/com/whiskey/rvcom/review/ReviewController.java
+++ b/src/main/java/com/whiskey/rvcom/review/ReviewController.java
@@ -3,7 +3,7 @@ package com.whiskey.rvcom.review;
 import com.whiskey.rvcom.entity.member.Member;
 import com.whiskey.rvcom.entity.restaurant.Restaurant;
 import com.whiskey.rvcom.entity.review.*;
-import com.whiskey.rvcom.repository.RestaurantRepository;
+import com.whiskey.rvcom.restaurant.service.RestaurantService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Controller
-@RequestMapping("/restaurant/review")
+//@RequestMapping("/restaurant/review")
 @RequiredArgsConstructor
 public class ReviewController {
-//    private final RestaurantServic restaurantService;
-    private final RestaurantRepository restaurantRepository;    // need. 서비스 모듈로 교체 필요(업요전달)
+    private final RestaurantService restaurantService;
+//    private final RestaurantRepository restaurantRepository;    // need. 서비스 모듈로 교체 필요(업요전달)
 
     private final ReviewService reviewService;
     private final ReviewCommentService reviewCommentService;
@@ -24,14 +24,24 @@ public class ReviewController {
 
     // use path variable
     // 리뷰 목록 조회 요청
-    @GetMapping("/{restaurantNo}")
-    public String getReviewsByRestaurantId(@PathVariable Long restaurantNo, Model model) {
-        Restaurant restaurant = restaurantRepository.findById(restaurantNo).orElseThrow();
-        List<Review> reviews = reviewService.getReviewsByRestaurant(restaurant);
+//    @GetMapping("/{restaurantNo}")
+//    public String getReviewsByRestaurantId(@PathVariable Long restaurantNo, Model model) {
+//        Restaurant restaurant = restaurantRepository.findById(restaurantNo).orElseThrow();
+//        List<Review> reviews = reviewService.getReviewsByRestaurant(restaurant);
+//
+//        model.addAttribute("reviews", reviews);     // desc. 리뷰 목록 바인딩
+//
+//        return "restaurantDetail";  // need. 뷰 분할 후 리뷰 페이지에 대한 뷰로 변경
+//    }
 
-        model.addAttribute("reviews", reviews);     // desc. 리뷰 목록 바인딩
+    @GetMapping("/restaurant/{restaurantId}/reviews")
+    public String getRestaurantDetailWithTab(@PathVariable Long restaurantId, Model model) {
+        Restaurant restaurant = restaurantService.getRestaurantById(restaurantId);
+        List<Review> reviewsByRestaurant = reviewService.getReviewsByRestaurant(restaurant);
 
-        return "restaurantDetail";  // need. 뷰 분할 후 리뷰 페이지에 대한 뷰로 변경
+        model.addAttribute("reviews", reviewsByRestaurant);
+
+        return "restaurantDetail";
     }
 
 //    @PostMapping("/list/{restaurantNo}")

--- a/src/main/resources/templates/fragments/restaurantDetail/reviews.html
+++ b/src/main/resources/templates/fragments/restaurantDetail/reviews.html
@@ -45,19 +45,30 @@
         <div class="recent-reviews">
             <h3><i class="fas fa-clock"></i> 최근 리뷰</h3>
             <!-- TODO: 백엔드 - 최근 리뷰를 날짜순으로 정렬하여 가져와 동적으로 표시 -->
-            <div class="review-items">
+            <div class="review-items" th:each="review : ${reviews}">
                 <!-- 리뷰 카드 fragment 사용 -->
+<!--                <div th:replace="fragments/reviewItem :: reviewItem(-->
+<!--                        title='맛있는 파스타와 분위기 좋은 레스토랑',-->
+<!--                        content='파스타가 정말 맛있었어요. 특히 트러플 크림 파스타는 꼭 드셔보세요!',-->
+<!--                        author='홍길동',-->
+<!--                        date='2024-05-01',-->
+<!--                        rating='★★★★☆ 4',-->
+<!--                        images='',-->
+<!--                        menuName='트러플 크림 파스타',-->
+<!--                        menuPrice='18,000'-->
+<!--                    )" th:attr="data-review-id=${reviewId}"></div>-->
+                <!-- 추가 리뷰 카드들... -->
+
                 <div th:replace="fragments/reviewItem :: reviewItem(
-                        title='맛있는 파스타와 분위기 좋은 레스토랑',
-                        content='파스타가 정말 맛있었어요. 특히 트러플 크림 파스타는 꼭 드셔보세요!',
-                        author='홍길동',
-                        date='2024-05-01',
-                        rating='★★★★☆ 4',
+                        title=${review.content},
+                        content=${review.content},
+                        author=${review.reviewer.nickname},
+                        date=${#temporals.format(review.createdAt, 'yyyy-MM-dd')},
+                        rating=${#strings.repeat('★', review.rating.value) + #strings.repeat('☆', 5 - review.rating.value)},
                         images='',
                         menuName='트러플 크림 파스타',
                         menuPrice='18,000'
                     )" th:attr="data-review-id=${reviewId}"></div>
-                <!-- 추가 리뷰 카드들... -->
             </div>
         </div>
         <button id="loadMoreReviews" class="load-more">더 보기</button>


### PR DESCRIPTION
/restaurant/{id}/reviews 엔드포인트에 배정

테스트는 id=2로 지정
id당 리뷰 리스트업하여 바인딩 완료

### 확인필요한 이슈
- Title이 불필요 혹은 Entity에 Title 정보 추가
- 이미지정보 바인딩 방식 논의필요
- 리뷰카드 하단 영수증 인식정보 표시방식 논의필요
- 좋아요/댓글 바인딩방식 논의필요

* 싫어요 버튼 제거 필요
---
![image](https://github.com/user-attachments/assets/1f8e1b3f-4f7d-4a0e-b090-29b6550f346d)
