### PR TITLE
(Feat/imageFile) MultipartFile 지원 및 파일 처리 개선

### DIFF
--- a/src/main/java/com/whiskey/rvcom/ImageFile/ImageFileService.java
+++ b/src/main/java/com/whiskey/rvcom/ImageFile/ImageFileService.java
@@ -34,6 +34,9 @@ public class ImageFileService {
     public ImageFile uploadFile(String filePath) throws Exception {
         logger.info("파일 업로드 및 엔티티 생성 중: {}", filePath);
 
+         // todo. 웹서버 로컬에 사용자가 요청한 파일을 다운로드하는 로직 추가
+
+         // todo. 웹서버 로컬에 저장된 파일을 다시 ncp 파일서버로 전송하는 로직으로 변경
         if (!new File(filePath).exists()) {
             logger.error("파일이 존재하지 않습니다: {}", filePath);
             throw new IllegalArgumentException("파일이 존재하지 않습니다.");
@@ -50,6 +53,8 @@ public class ImageFileService {
         ImageFile imageFile = new ImageFile();
         imageFile.setOriginalFileName(uploadedFileName.getOriginalFileName());
         imageFile.setUuidFileName(uploadedFileName.getUuidFileName());
+
+          // todo. 웹서버 로컬에 저장된 파일 삭제
 
         return imageFileRepository.save(imageFile);
     }

--- a/src/main/java/com/whiskey/rvcom/ImageFile/ImageFileService.java
+++ b/src/main/java/com/whiskey/rvcom/ImageFile/ImageFileService.java
@@ -9,10 +9,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class ImageFileService {
@@ -23,40 +29,78 @@ public class ImageFileService {
     @Autowired
     private ImageFileRepository imageFileRepository;
 
+    private final String host; // NCP 파일서버 주소(임의로 테스트 때문에 설정)
+
+    public ImageFileService() {
+        this.host = "http://web.dokalab.site:8083";
+    }
+
     /**
      * 이미지 파일을 업로드하고 해당 파일의 엔티티를 생성합니다.
      * 
-     * @param filePath 업로드할 파일의 경로
+     * @param multipartFile 사용자가 업로드한 MultipartFile 객체
      * @return 생성된 ImageFile 엔티티
      * @throws Exception 파일 업로드 실패 또는 유효하지 않은 파일 형식일 경우 발생
      */
     @Transactional
-    public ImageFile uploadFile(String filePath) throws Exception {
-        logger.info("파일 업로드 및 엔티티 생성 중: {}", filePath);
+    public ImageFile uploadFile(MultipartFile multipartFile) throws Exception {
+        logger.info("파일 업로드 및 엔티티 생성 중: {}", multipartFile.getOriginalFilename());
 
-         // todo. 웹서버 로컬에 사용자가 요청한 파일을 다운로드하는 로직 추가
+        // 1. 웹서버 로컬에 사용자가 요청한 파일을 다운로드하는 로직
+        String localFilePath = saveFileLocally(multipartFile);
 
-         // todo. 웹서버 로컬에 저장된 파일을 다시 ncp 파일서버로 전송하는 로직으로 변경
-        if (!new File(filePath).exists()) {
-            logger.error("파일이 존재하지 않습니다: {}", filePath);
-            throw new IllegalArgumentException("파일이 존재하지 않습니다.");
-        }
-
-        if (!isImageFile(filePath)) {
-            logger.error("유효하지 않은 이미지 파일 형식입니다: {}", filePath);
+        // 2. 웹서버 로컬에 저장된 파일을 다시 ncp 파일서버로 전송하는 로직
+        if (!isImageFile(localFilePath)) {
+            logger.error("유효하지 않은 이미지 파일 형식입니다: {}", localFilePath);
+            deleteFileLocally(localFilePath);
             throw new IllegalArgumentException("유효하지 않은 이미지 파일 형식입니다.");
         }
 
-        FileUploader fileUploader = new FileUploader(filePath);
+        FileUploader fileUploader = new FileUploader(localFilePath, this.host);
         FileNameGroup uploadedFileName = fileUploader.upload();
 
         ImageFile imageFile = new ImageFile();
         imageFile.setOriginalFileName(uploadedFileName.getOriginalFileName());
         imageFile.setUuidFileName(uploadedFileName.getUuidFileName());
 
-          // todo. 웹서버 로컬에 저장된 파일 삭제
+        // 3. 웹서버 로컬에 저장된 파일 삭제
+        deleteFileLocally(localFilePath);
 
         return imageFileRepository.save(imageFile);
+    }
+
+    /**
+     * MultipartFile을 웹서버 로컬에 저장합니다.
+     * 
+     * @param multipartFile 사용자가 업로드한 MultipartFile 객체
+     * @return 저장된 로컬 파일 경로
+     * @throws IOException 파일 저장 중 오류 발생 시
+     */
+    private String saveFileLocally(MultipartFile multipartFile) throws IOException {
+        String fileName = UUID.randomUUID().toString() + "_" + multipartFile.getOriginalFilename();
+        // 서버의 특정 디렉토리를 지정합니다. 예를 들어, "/app/multipartfiletest/"
+        Path uploadDir = Paths.get("/app/multipartfiletest/");
+        if (!Files.exists(uploadDir)) {
+            Files.createDirectories(uploadDir);
+        }
+        Path path = uploadDir.resolve(fileName);
+        Files.write(path, multipartFile.getBytes());
+        logger.info("파일을 서버 로컬에 저장했습니다: {}", path);
+        return path.toString();
+    }
+
+    /**
+     * 웹서버 로컬에 저장된 파일을 삭제합니다.
+     * 
+     * @param filePath 삭제할 파일 경로
+     */
+    private void deleteFileLocally(String filePath) {
+        try {
+            Files.deleteIfExists(Paths.get(filePath));
+            logger.info("로컬 파일을 삭제했습니다: {}", filePath);
+        } catch (IOException e) {
+            logger.error("로컬 파일 삭제 중 오류 발생: {}", filePath, e);
+        }
     }
 
     /**

--- a/src/test/java/com/whiskey/rvcom/ImageFile/ImageFileServiceTest.java
+++ b/src/test/java/com/whiskey/rvcom/ImageFile/ImageFileServiceTest.java
@@ -11,6 +11,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,7 +41,7 @@ public class ImageFileServiceTest {
     @MockBean
     private ImageFileRepository imageFileRepository;
 
-    private final String filePath = "C:\\Users\\kebin\\Desktop\\racoon-pedro.gif";
+    private final String filePath = "C:\\Users\\choo\\Desktop\\racoon-pedro.gif";
     private final String host = "http://web.dokalab.site:8083";
 
     /**
@@ -49,53 +59,143 @@ public class ImageFileServiceTest {
 
     /**
      * 실제 NCP 서버에 파일을 업로드하는 기능을 테스트합니다.
-     * FileUploader를 사용하여 파일을 업로드하고, 결과를 검증합니다.
+     * MultipartFile을 사용하여 파일을 업로드하고, 결과를 검증합니다.
      */
     @Test
     public void testFileUpload() throws Exception {
         logger.info("실제 NCP 서버 파일 업로드 테스트 시작: {}", filePath);
+    
+        // 테스트용 MultipartFile 생성
+        File file = new File(filePath);
+        FileInputStream input = new FileInputStream(file);
+        MultipartFile multipartFile = new MockMultipartFile("file",
+                file.getName(), "image/gif", input);
+    
+        // FileUploader를 생성할 때 host 변수 사용
+        FileUploader fileUploader = new FileUploader(filePath, host);
+        
+        // 파일 업로드 실행
+        FileNameGroup uploadedFileName = fileUploader.upload();
+    
+        assertNotNull(uploadedFileName);
+        assertNotNull(uploadedFileName.getOriginalFileName());
+        assertNotNull(uploadedFileName.getUuidFileName());
+        assertTrue(uploadedFileName.getOriginalFileName().endsWith("racoon-pedro.gif"));
+        logger.info("실제 NCP 서버 파일 업로드 성공: {} -> {}", uploadedFileName.getOriginalFileName(), uploadedFileName.getUuidFileName());
+    }
 
-        FileUploader realFileUploader = new FileUploader(filePath, host);
-        FileNameGroup result = realFileUploader.upload();
+    /**
+     * 실제 NCP 서버에 파일을 업로드하는 기능을 테스트합니다.
+     * 모의 객체가 아닌 실제 MultipartFile을 사용하여 파일을 업로드하고, 결과를 검증합니다.
+     */
+    @Test
+    public void testRealFileUpload() throws Exception {
+        logger.info("실제 NCP 서버 파일 업로드 테스트 시작: {}", filePath);
+    
+        // 실제 파일로 MultipartFile 생성
+        File file = new File(filePath);
+        FileInputStream input = new FileInputStream(file);
+        MultipartFile multipartFile = new MultipartFile() {
+            @Override
+            public String getName() {
+                return "file";
+            }
+    
+            @Override
+            public String getOriginalFilename() {
+                return file.getName();
+            }
+    
+            @Override
+            public String getContentType() {
+                return "image/gif";
+            }
+    
+            @Override
+            public boolean isEmpty() {
+                return file.length() == 0;
+            }
+    
+            @Override
+            public long getSize() {
+                return file.length();
+            }
+    
+            @Override
+            public byte[] getBytes() throws IOException {
+                return Files.readAllBytes(file.toPath());
+            }
+    
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return new FileInputStream(file);
+            }
+    
+            @Override
+            public void transferTo(File dest) throws IOException, IllegalStateException {
+                Files.copy(file.toPath(), dest.toPath());
+            }
+        };
+        logger.info("MultipartFile 생성 완료: 원본 파일 이름 = {}, 크기 = {} bytes", multipartFile.getOriginalFilename(), multipartFile.getSize());
+
+        // ImageFileService를 사용하여 파일 업로드(현재 이 테스트 코드에서는 작동이 안됨.)
+        logger.info("파일 업로드 시작: {}", multipartFile.getOriginalFilename());
+        ImageFile result = imageFileService.uploadFile(multipartFile);
+        logger.info("파일 업로드 완료: {}", result);
 
         assertNotNull(result);
+        logger.info("결과 객체가 null이 아님을 확인");
+
         assertNotNull(result.getOriginalFileName());
+        logger.info("원본 파일 이름이 null이 아님을 확인");
+
         assertNotNull(result.getUuidFileName());
+        logger.info("UUID 파일 이름이 null이 아님을 확인");
+
         assertTrue(result.getOriginalFileName().endsWith("racoon-pedro.gif"));
-        logger.info("실제 NCP 서버 파일 업로드 성공: {} -> {}", result.getOriginalFileName(), result.getUuidFileName());
+        logger.info("원본 파일 이름이 'racoon-pedro.gif'로 끝남을 확인");
+
+        logger.info("ImageFileService를 사용한 실제 NCP 서버 파일 업로드 성공: {} -> {}", result.getOriginalFileName(), result.getUuidFileName());
     }
-        
+
     /**
      * 유효하지 않은 파일 확장자를 가진 파일을 업로드하려 할 때 예외가 발생하는지 테스트합니다.
      * IllegalArgumentException이 발생하고, 적절한 에러 메시지가 포함되어 있는지 확인합니다.
      */
     @Test
-    public void testInvalidFileExtension() {
-        String invalidFilePath = "C:\\Users\\kebin\\Desktop\\invalid.txt";
+    public void testInvalidFileExtension() throws IOException {
+        String invalidFilePath = "C:\\Users\\choo\\Desktop\\invalid.txt";
         logger.info("유효하지 않은 파일 확장자 테스트 시작: {}", invalidFilePath);
 
+        File file = new File(invalidFilePath);
+        FileInputStream input = new FileInputStream(file);
+        MultipartFile multipartFile = new MockMultipartFile("file",
+                file.getName(), "text/plain", input);
+
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            imageFileService.uploadFile(invalidFilePath);
+            imageFileService.uploadFile(multipartFile);
         });
 
         assertEquals("유효하지 않은 이미지 파일 형식입니다.", exception.getMessage());
-        logger.info("유효하지 않은 파일 확장자 테스트 성공");
+        logger.info("유효하지 않은 파일 확장자 테스트 성공"); // 테스트 작동 확인
     }
 
     /**
      * 존재하지 않는 파일을 업로드하려 할 때 예외가 발생하는지 테스트합니다.
-     * IllegalArgumentException이 발생하고, 적절한 에러 메시지가 포함되어 있는지 확인합니다.
+     * IOException이 발생하는지 확인합니다.
      */
     @Test
     public void testNonExistentFile() {
-        String nonExistentFilePath = "C:\\Users\\kebin\\Desktop\\non-existent.jpg";
+        String nonExistentFilePath = "C:\\Users\\choo\\Desktop\\non-existent.jpg";
         logger.info("존재하지 않는 파일 테스트 시작: {}", nonExistentFilePath);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            imageFileService.uploadFile(nonExistentFilePath);
+        MultipartFile multipartFile = new MockMultipartFile("file",
+                "non-existent.jpg", "image/jpeg", new byte[0]);
+
+        assertThrows(IOException.class, () -> {
+            imageFileService.uploadFile(multipartFile);
         });
 
-        assertEquals("파일이 존재하지 않습니다.", exception.getMessage());
-        logger.info("존재하지 않는 파일 테스트 성공");
+        logger.info("존재하지 않는 파일 테스트 성공"); // 테스트 작동 확인
     }
 }


### PR DESCRIPTION
# MultipartFile 지원 및 파일 처리 개선

## 변경 사항 요약
- ImageFileService에 MultipartFile 지원 추가
- 로컬 파일 처리 기능 구현
- 테스트 케이스 업데이트

## 상세 변경 내용

### ImageFileService
- uploadFile 메서드가 MultipartFile을 매개변수로 받도록 수정
- 로컬 파일 저장 (saveFileLocally) 및 삭제 (deleteFileLocally) 메서드 추가
- 작동 테스트를 위한 NCP 파일 서버 주소를 위한 host 필드 추가

### ImageFileServiceTest
- MultipartFile을 사용한 새로운 테스트 케이스 추가
- 실제 NCP 서버 파일 업로드 테스트 로직 개선
- 유효하지 않은 파일 확장자 및 존재하지 않는 파일에 대한 테스트 업데이트

## 영향 및 주의사항
- 기존 String 파일 경로 대신 MultipartFile을 사용하는 방식으로 변경되었으므로, 관련 코드 수정 필요

## 테스트 결과
- 모든 단위 테스트 통과
- 실제 NCP 서버와의 연동 테스트 성공
```
2024-08-20T21:55:07.319+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : 실제 NCP 서버 파일 업로드 테스트 시작: C:\Users\choo\Desktop\racoon-pedro.gif
2024-08-20T21:55:07.319+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : MultipartFile 생성 완료: 원본 파일 이름 = racoon-pedro.gif, 크기 = 2901839 bytes
2024-08-20T21:55:07.319+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : 파일 업로드 시작: racoon-pedro.gif
2024-08-20T21:55:07.330+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.rvcom.ImageFile.ImageFileService     : 파일 업로드 및 엔티티 생성 중: racoon-pedro.gif
2024-08-20T21:55:07.337+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.rvcom.ImageFile.ImageFileService     : 파일을 서버 로컬에 저장했습니다: \app\multipartfiletest\76350354-39cb-40f8-a1d6-878c24091a44_racoon-pedro.gif
2024-08-20T21:55:07.996+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.rvcom.ImageFile.ImageFileService     : 로컬 파일을 삭제했습니다: \app\multipartfiletest\76350354-39cb-40f8-a1d6-878c24091a44_racoon-pedro.gif
2024-08-20T21:55:08.007+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : 파일 업로드 완료: com.whiskey.rvcom.entity.resource.ImageFile@6e609e8a
2024-08-20T21:55:08.009+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : 결과 객체가 null이 아님을 확인
2024-08-20T21:55:08.010+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : 원본 파일 이름이 null이 아님을 확인
2024-08-20T21:55:08.010+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : UUID 파일 이름이 null이 아님을 확인
2024-08-20T21:55:08.010+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : 원본 파일 이름이 'racoon-pedro.gif'로 끝남을 확인
2024-08-20T21:55:08.010+09:00  INFO 22916 --- [rvcom] [    Test worker] c.w.r.ImageFile.ImageFileServiceTest     : ImageFileService를 사용한 실제 NCP 서버 파일 업로드 성공: 76350354-39cb-40f8-a1d6-878c24091a44_racoon-pedro.gif -> 0bbd1dbf-e201-4ae6-928e-2894230089c8.gif

```