### PR TITLE
음식점 리뷰페이지 리뷰카드 정보 바인딩 작업 수행

### DIFF
--- a/src/main/java/com/whiskey/rvcom/entity/review/Review.java
+++ b/src/main/java/com/whiskey/rvcom/entity/review/Review.java
@@ -2,6 +2,7 @@ package com.whiskey.rvcom.entity.review;
 
 import com.whiskey.rvcom.entity.member.Member;
 import com.whiskey.rvcom.entity.receipt.ReceiptData;
+import com.whiskey.rvcom.entity.resource.ImageFile;
 import com.whiskey.rvcom.entity.restaurant.Restaurant;
 import jakarta.persistence.*;
 import lombok.*;
@@ -41,6 +42,9 @@ public class Review {
     @JoinColumn(name = "restaurant_id", nullable = false)
     private Restaurant restaurant;  // 음식점 객체의 정보
 
+    @OneToMany(mappedBy = "review", fetch = FetchType.EAGER)
+    private List<ReviewImage> reviewImages; // 리뷰 이미지 리스트
+
     @ManyToOne
     @JoinColumn(name = "reviewer_id", nullable = false)
     private Member reviewer;    // 리뷰 작성자
@@ -51,4 +55,7 @@ public class Review {
     @OneToOne
     @JoinColumn(name = "receipt_data_id", nullable = false)
     private ReceiptData receiptData;    // 영수증 정보
+
+    @OneToMany(mappedBy = "review", fetch = FetchType.EAGER)
+    private List<ReviewComment> reviewComments; // 리뷰 댓글 리스트
 }

--- a/src/main/java/com/whiskey/rvcom/review/ReviewController.java
+++ b/src/main/java/com/whiskey/rvcom/review/ReviewController.java
@@ -21,6 +21,7 @@ public class ReviewController {
     private final ReviewService reviewService;
     private final ReviewCommentService reviewCommentService;
     private final ReviewLikeService reviewLikeService;
+    private final ReviewImageService reviewImageService;
 
     // use path variable
     // 리뷰 목록 조회 요청
@@ -39,6 +40,12 @@ public class ReviewController {
         Restaurant restaurant = restaurantService.getRestaurantById(restaurantId);
         List<Review> reviewsByRestaurant = reviewService.getReviewsByRestaurant(restaurant);
 
+        reviewsByRestaurant.sort((r1, r2) -> r2.getCreatedAt().compareTo(r1.getCreatedAt()));
+
+        // review 각각에서 isSuspended가 false인 review만 가져오기
+        reviewsByRestaurant.removeIf(review -> review.isSuspended());
+
+        model.addAttribute("restaurant", restaurant);
         model.addAttribute("reviews", reviewsByRestaurant);
 
         return "restaurantDetail";

--- a/src/main/resources/templates/fragments/restaurantDetail/reviews.html
+++ b/src/main/resources/templates/fragments/restaurantDetail/reviews.html
@@ -65,10 +65,11 @@
                         author=${review.reviewer.nickname},
                         date=${#temporals.format(review.createdAt, 'yyyy-MM-dd')},
                         rating=${#strings.repeat('★', review.rating.value) + #strings.repeat('☆', 5 - review.rating.value)},
-                        images='',
-                        menuName='트러플 크림 파스타',
-                        menuPrice='18,000'
-                    )" th:attr="data-review-id=${reviewId}"></div>
+                        images=${review.reviewImages},
+                        menus=${review.receiptData},
+                        likes=${review.likes},
+                        comments=${review.reviewComments}
+                    )" th:attr="data-review-id=${review.id}"></div>
             </div>
         </div>
         <button id="loadMoreReviews" class="load-more">더 보기</button>

--- a/src/main/resources/templates/fragments/reviewItem.html
+++ b/src/main/resources/templates/fragments/reviewItem.html
@@ -1,5 +1,5 @@
 <!-- src/main/resources/templates/fragments/reviewItem.html -->
-<div th:fragment="reviewItem(title, content, author, date, rating, images, menuName, menuPrice)">
+<div th:fragment="reviewItem(title, content, author, date, rating, images, menus, likes, comments)">
     <div class="review-item">
         <button style="float: right;" id="reviewReport">신고하기</button>
         <h4 class="review-title" th:text="${title}">리뷰 제목</h4>
@@ -13,26 +13,84 @@
                 <div class="rating" th:text="${rating}">평점</div>
             </div>
         </div>
-        <div class="review-images">
-            <!-- TODO: 이미지 표시 로직 구현 
-                 - 이미지 목록을 순회하며 표시
-                 - 이미지 크기 조정 및 레이아웃 최적화
-                 - 이미지 클릭 시 확대 기능 추가 -->
-            <img src="https://via.placeholder.com/150" alt="Review Image 1" class="review-image">
-            <img src="https://via.placeholder.com/150" alt="Review Image 2" class="review-image">
-            <img src="https://via.placeholder.com/150" alt="Review Image 3" class="review-image">
-            <div class="more-images">
-                <span>+ 더보기</span>
+<!--        <div class="review-images">-->
+<!--            &lt;!&ndash; TODO: 이미지 표시 로직 구현-->
+<!--                 - 이미지 목록을 순회하며 표시-->
+<!--                 - 이미지 크기 조정 및 레이아웃 최적화-->
+<!--                 - 이미지 클릭 시 확대 기능 추가 &ndash;&gt;-->
+<!--&lt;!&ndash;            <img th:src=@{${images.filePath}} src="https://via.placeholder.com/150" alt="Review Image 1" class="review-image">&ndash;&gt;-->
+<!--&lt;!&ndash;            <img src="https://via.placeholder.com/150" alt="Review Image 2" class="review-image">&ndash;&gt;-->
+<!--&lt;!&ndash;            <img src="https://via.placeholder.com/150" alt="Review Image 3" class="review-image">&ndash;&gt;-->
+
+<!--            <img th:each="image : ${images}" th:src="@{|https://kr.object.ncloudstorage.com/whiskey-file/${image.imageFile.uuidFileName}|}" alt="Review Image" class="review-image">-->
+<!--&lt;!&ndash;            <img src="https://kr.object.ncloudstorage.com/whiskey-file/279278f9-41d5-408c-b477-0850bd1a8c41.jpg" alt="Review Image 3" class="review-image">&ndash;&gt;-->
+<!--            <div class="more-images">-->
+<!--                <span>+ 더보기</span>-->
+<!--            </div>-->
+<!--        </div>-->
+
+<!--        <div class="review-images" th:if="${images.size() > 0}">-->
+<!--            <div class="image-container">-->
+<!--                <img th:each="image, iterStat : ${images}"-->
+<!--                     th:if="${iterStat.index < 4}"-->
+<!--                     th:src="@{|https://kr.object.ncloudstorage.com/whiskey-file/${image.imageFile.uuidFileName}|}"-->
+<!--                     alt="Review Image"-->
+<!--                     class="review-image">-->
+
+<!--                &lt;!&ndash; 더보기 버튼 조건 &ndash;&gt;-->
+<!--                <div th:if="${images.size() > 4}" class="more-images">-->
+<!--                    <span>+ 더보기</span>-->
+<!--                </div>-->
+<!--            </div>-->
+<!--        </div>-->
+
+        <div class="review-images" th:if="${images.size() > 0}">
+            <div class="image-container" style="display: flex; gap: 10px; flex-wrap: wrap;">
+                <div th:each="image, iterStat : ${images}" th:if="${iterStat.index < 4}">
+                    <img th:src="@{|https://kr.object.ncloudstorage.com/whiskey-file/${image.imageFile.uuidFileName}|}"
+                         alt="Review Image"
+                         class="review-image">
+                </div>
+
+                <!-- 더보기 버튼 조건 -->
+                <div th:if="${images.size() > 4}" class="more-images">
+                    <span>+ 더보기</span>
+                </div>
             </div>
         </div>
+
+
         <div class="menu-info">
-            <span class="menu-name" th:text="${menuName}">메뉴 이름</span>
-            <span class="menu-price" th:text="${menuPrice + '원'}">메뉴 가격</span>
+<!--            <span class="menu-name">메뉴 이름</span>-->
+<!--            <span class="menu-price">메뉴 가격</span>-->
+
+<!--            <span class="menu-name"><p th:text="${menu.itemName}"></p></span>-->
+<!--            <span class="menu-price">메뉴 가격</span>-->
+
+            <div th:each="menu : ${menus.paidItems}">
+                <span th:text="${'메뉴 이름: ' + menu.itemName + ' / '}">메뉴 이름</span>
+                <span th:text="${'단가: ' + menu.price + '원 / '}">메뉴 가격</span>
+                <span th:text="${'수량: ' + menu.quantity}">메뉴 이름</span>
+            </div>
+
+<!--            <p class="menu-name" th:text="${'메뉴 이름: ' + menu.itemName}">메뉴 이름</p>-->
+<!--            <p class="menu-price" th:text="${'단가: ' + menu.price + '원'}">메뉴 가격</p>-->
+<!--            <p class="menu-name" th:text="${'수량: ' + menu.quantity}">메뉴 이름</p>-->
+
+<!--            <p th:text="${'총 금액: ' + menus.totalPrice}"}></p>-->
         </div>
         <div class="review-actions">
-            <button class="like-button">👍 좋아요 (15)</button>
-            <button class="dislike-button">👎 싫어요 (2)</button>
-            <button class="comment-button">💬 댓글 (3)</button>
+<!--            <button class="like-button">👍 좋아요 (15)</button>-->
+            <button class="like-button">
+                <span th:text="'👍 좋아요 (' + ${likes.size()} + ')'"></span>
+            </button>
+<!--            <button class="dislike-button">👎 싫어요 (2)</button>-->
+<!--            <button class="comment-button">💬 댓글 (3)</button>-->
+            <button class="comment-button">
+                <span th:text="'💬 댓글 (' + ${comments.size()} + ')'"></span>
+            </button>
+
+<!--            <button class="comment-button"><span th:text="💬 댓글${reviewCommentCount}"></span></button>-->
         </div>
         <div class="comments-section" style="display: none;">
             <div class="comments-list">
@@ -41,20 +99,30 @@
                      - 페이지네이션 구현
                      - 댓글 정렬 기능 추가 (최신순, 추천순 등) -->
                 <!-- 예시 댓글 -->
-                <div class="comment">
-                    <p>정말 맛있어 보이네요! 꼭 가보고 싶습니다.</p>
-                    <button style="float: right;" id="commentReport">신고하기</button> <!-- 이 버튼도 같이 부탁드릴게용 -->
-                    <span>김철수 - 2024-05-20</span>
+                <div class="comment" th:each="comment : ${comments}">
+                    <p th:text="${comment.content}"></p>
+                    <button style="float: right;" id="commentReport">신고하기</button>
+                    <span th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd')} + ' / ' + ${comment.commenter.nickname}"></span>
                 </div>
-                <div class="comment">
-                    <p>트러플 크림 파스타 저도 먹어봤는데 정말 맛있었어요!</p>
-                    <span>이영희 - 2024-05-21</span>
-                </div>
-                <div class="comment">
-                    <p>가격대비 양은 어떤가요?</p>
-                    <span>박지성 - 2024-05-22</span>
+<!--                <div class="comment" th:each="comment : ${comments}">-->
+<!--                    <p th:text="${comment.content}"></p>-->
+<!--&lt;!&ndash;                    <a th:href="/report/${comment.id}"></a>&ndash;&gt;-->
+<!--&lt;!&ndash;                    <span th:text="${comment.formated}"></span>&ndash;&gt;-->
+<!--                </div>-->
+<!--                <div class="comment">-->
+<!--                    <p>정말 맛있어 보이네요! 꼭 가보고 싶습니다.</p>-->
+<!--                    <button style="float: right;" id="commentReport">신고하기</button> &lt;!&ndash; 이 버튼도 같이 부탁드릴게용 &ndash;&gt;-->
+<!--                    <span>김철수 - 2024-05-20</span>-->
+<!--                </div>-->
+<!--                <div class="comment">-->
+<!--                    <p>트러플 크림 파스타 저도 먹어봤는데 정말 맛있었어요!</p>-->
+<!--                    <span>이영희 - 2024-05-21</span>-->
+<!--                </div>-->
+<!--                <div class="comment">-->
+<!--                    <p>가격대비 양은 어떤가요?</p>-->
+<!--                    <span>박지성 - 2024-05-22</span>-->
 
-                </div>
+<!--                </div>-->
             </div>
             <div class="comment-form">
                 <textarea class="comment-input" placeholder="댓글을 입력하세요"></textarea>


### PR DESCRIPTION
### 적용사항
* Review엔티티 명세사항 일부 필드 양방향 관계 설정을 위한 필드 추가
  - reviewComment
  - reviewImage
불필요한 내 추가참조 횟수 단축을 통한 클라이언트단 요청 클럭 수 단축을 위한 수정

1. 리뷰 당 '좋아요' 개수 반영
2. 리뷰 당 '댓글' 개수 반영
3. 리뷰 당 '이미지' 페이지 바인딩
  - 이미지 5개 초과 시 '더보기' 추가되도록 수정
4. 리뷰 댓글 버튼 클릭 시 연관 리뷰댓글 리스트 표시되도록 바인딩
  - 리뷰 카드에 사용자 닉네임 정보 추가로 바인딩
5. 리뷰카드에 해당 사용자가 결제한 결제내역(영수증 인식정보) 바인딩
  - todo. 해당 사용자의 주문건 '총결제액' 행 추가예정
  - todo. 주문단가 및 총결제액을 1000단위로 ','처리

![image](https://github.com/user-attachments/assets/0ea609f4-62fe-4419-b9a5-9eae90c4b7dd)
