### PR TITLE
feat: 음식점 커버 이미지 불러와 음식점 정보에 표시

### DIFF
--- a/src/main/java/com/whiskey/rvcom/restaurant/controller/restaurantController.java
+++ b/src/main/java/com/whiskey/rvcom/restaurant/controller/restaurantController.java
@@ -4,6 +4,7 @@ import com.whiskey.rvcom.entity.restaurant.Restaurant;
 import com.whiskey.rvcom.entity.restaurant.menu.Menu;
 import com.whiskey.rvcom.restaurant.service.RestaurantService;
 import com.whiskey.rvcom.review.ReviewService;
+import com.whiskey.rvcom.util.ImagePathParser;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,6 +35,10 @@ public class restaurantController {
 
         model.addAttribute("restaurant", restaurant);
         model.addAttribute("restaurantId", restaurantId);
+
+        if (restaurant.getCoverImage() != null) {
+            model.addAttribute("restaurantCoverImageUrl", ImagePathParser.parse(restaurant.getCoverImage().getUuidFileName()));
+        }
 
         model.addAttribute("tab", tab); // 저 탭과 관련한 내용은 PathVariable이 아닌 상수 info 로~
 

--- a/src/main/java/com/whiskey/rvcom/restaurant/dto/RestaurantCardDTO.java
+++ b/src/main/java/com/whiskey/rvcom/restaurant/dto/RestaurantCardDTO.java
@@ -14,4 +14,5 @@ public class RestaurantCardDTO {
     private String category;
     private String distance;
     private String openCloseTime;
+    private String coverImageUrl;
 }

--- a/src/main/java/com/whiskey/rvcom/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/whiskey/rvcom/restaurant/service/RestaurantService.java
@@ -8,6 +8,7 @@ import com.whiskey.rvcom.repository.MenuRepository;
 import com.whiskey.rvcom.repository.RestaurantRepository;
 import com.whiskey.rvcom.restaurant.dto.RestaurantCardDTO;
 import com.whiskey.rvcom.restaurant.dto.RestaurantSearchResultDTO;
+import com.whiskey.rvcom.util.ImagePathParser;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -78,12 +79,18 @@ public class RestaurantService {
                 break;
         }
 
+        String coverImageUrl = null;
+        if (restaurant.getCoverImage() != null) {
+            coverImageUrl = ImagePathParser.parse(restaurant.getCoverImage().getUuidFileName());
+        }
+
         RestaurantCardDTO restaurantCardDTO = new RestaurantCardDTO(
                 restaurant.getId(),
                 restaurant.getName(),
                 restaurant.getCategory().name(),
                 distanceString,
-                openingHour
+                openingHour,
+                coverImageUrl
         );
 
         return restaurantCardDTO;

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -66,3 +66,9 @@ body {
 .tab-content {
     padding-bottom: 20px;
 }
+
+.review-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}

--- a/src/main/resources/static/js/currentLocationMain.js
+++ b/src/main/resources/static/js/currentLocationMain.js
@@ -88,9 +88,10 @@ function getLocationRestaurant(lat, lng) {
                     var element = document.createElement('div');
                     element.className = 'pop-in';
                     element.innerHTML = `<div class="restaurant-card">
-                            <div class="restaurant-image-placeholder">
-                                음식점 사진
-                            </div>
+                            <div class="restaurant-image-placeholder">` +
+                        (restaurant.coverImageUrl != null ? `<img src="${restaurant.coverImageUrl}" alt="등록된 사진이 없습니다." class="review-image">` : `<img alt="등록된 사진이 없습니다." class="review-image">`)
+                        +
+                        `</div>
                             <div class="restaurant-info">
                                 <h3>${restaurant.name}</h3>
                                 <p class="restaurant-details">

--- a/src/main/resources/static/js/currentLocationMain.js
+++ b/src/main/resources/static/js/currentLocationMain.js
@@ -89,7 +89,7 @@ function getLocationRestaurant(lat, lng) {
                     element.className = 'pop-in';
                     element.innerHTML = `<div class="restaurant-card">
                             <div class="restaurant-image-placeholder">` +
-                        (restaurant.coverImageUrl != null ? `<img src="${restaurant.coverImageUrl}" alt="등록된 사진이 없습니다." class="review-image">` : `<img alt="등록된 사진이 없습니다." class="review-image">`)
+                        (restaurant.coverImageUrl != null ? `<img src="${restaurant.coverImageUrl}" alt="등록된 사진이 없습니다." class="review-image">` : `등록된 사진이 없습니다`)
                         +
                         `</div>
                             <div class="restaurant-info">

--- a/src/main/resources/templates/fragments/restaurantBanner.html
+++ b/src/main/resources/templates/fragments/restaurantBanner.html
@@ -1,6 +1,6 @@
 <!-- src/main/resources/templates/fragments/restaurantBanner.html -->
-<div th:fragment="restaurantBanner(name, rating, reviewCount, price, category, status, hours)">
-    <div class="restaurant-banner" style="background-image: url('https://via.placeholder.com/1200x400');">
+<div th:fragment="restaurantBanner(name, imageUrl, rating, reviewCount, price, category, status, hours)">
+    <div class="restaurant-banner" th:style="'background-image: url(' + ${imageUrl} + ');'">
         <div class="container">
             <div class="restaurant-info">
                 <h1 class="restaurant-name" th:text="${name}">레스토랑 이름</h1>

--- a/src/main/resources/templates/restaurantDetail.html
+++ b/src/main/resources/templates/restaurantDetail.html
@@ -27,6 +27,7 @@
 -->
 <div th:replace="fragments/restaurantBanner :: restaurantBanner(
         name=${restaurant.getName()},
+        imageUrl=${restaurantCoverImageUrl != null ? restaurantCoverImageUrl:'https://via.placeholder.com/1200x400'},
         rating='★★★★☆',
         reviewCount='1,234',
         price='₩₩',


### PR DESCRIPTION
- 메인페이지에서 음식점의 컵버이미지가 존재하는 경우 아래와 같이 이미지를 불러와 표시
<img width="521" alt="image" src="https://github.com/user-attachments/assets/31fadb3e-73c4-455b-881e-702d8bea6865">

- 음식점 상세 페이지에서 음식점의 커버 이미지를 음식점 배너의 배경으로 설정
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/9b046f1d-a3df-4171-a551-9b13da265f4c">
