### PR TITLE
feat:헤더 수정, 마이페이지 즐겨찾기 비동기처리

### DIFF
--- a/src/main/java/com/whiskey/rvcom/Member/controller/MemberController.java
+++ b/src/main/java/com/whiskey/rvcom/Member/controller/MemberController.java
@@ -11,9 +11,11 @@ import com.whiskey.rvcom.entity.resource.ImageFile;
 import com.whiskey.rvcom.entity.restaurant.Restaurant;
 import com.whiskey.rvcom.entity.review.Review;
 import com.whiskey.rvcom.favorite.FavoriteService;
+import com.whiskey.rvcom.restaurant.service.RestaurantService;
 import com.whiskey.rvcom.review.ReviewImageService;
 import com.whiskey.rvcom.review.ReviewService;
 import com.whiskey.rvcom.util.ImagePathParser;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -45,11 +47,12 @@ public class MemberController {
     private final ImageFileService imageFileService;
     private final ReviewImageService reviewImageService;
     private final FavoriteService favoriteService;
+    private final RestaurantService restaurantService;
 
     @Autowired
     public MemberController(ReviewService reviewService, SocialLoginService socialLoginService,
                             MemberManagementService memberManagementService, PasswordEncoder passwordEncoder,
-                            RestTemplate restTemplate, ImageFileService imageFileService, ReviewImageService reviewImageService, FavoriteService favoriteService) {
+                            RestTemplate restTemplate, ImageFileService imageFileService, ReviewImageService reviewImageService, FavoriteService favoriteService, RestaurantService restaurantService) {
         this.reviewService = reviewService;
         this.socialLoginService = socialLoginService;
         this.memberManagementService = memberManagementService;
@@ -58,6 +61,7 @@ public class MemberController {
         this.imageFileService = imageFileService;
         this.reviewImageService = reviewImageService;
         this.favoriteService = favoriteService;
+        this.restaurantService = restaurantService;
     }
 
     @GetMapping("/login")
@@ -106,25 +110,28 @@ public class MemberController {
     }
 
     @PostMapping("/mypage/remove-favorite")
-    public String removeFavorite(HttpSession session, @RequestParam("restaurantId") Long restaurantId,
-                                 @RequestParam("favoritePage") int favoritePage,
-                                 @RequestParam("favoriteSize") int favoriteSize) {
+    @ResponseBody
+    public ResponseEntity<String> removeFavorite(@RequestParam("restaurantId") Long restaurantId, HttpSession session) {
         Member member = (Member) session.getAttribute("member");
 
         if (member == null) {
-            return "redirect:/login";
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
         }
 
-        // 레스토랑 ID를 사용해 해당 레스토랑을 찾음
-        Restaurant restaurant = favoriteService.findRestaurantById(restaurantId);
+        try {
+            // restaurantId를 사용하여 Restaurant 객체를 조회
+            Restaurant restaurant = restaurantService.getRestaurantById(restaurantId);
 
-        if (restaurant != null) {
+            // 조회된 Restaurant 객체를 removeFavorite 메서드에 전달
             favoriteService.removeFavorite(member, restaurant);
+            return ResponseEntity.ok("즐겨찾기가 해제되었습니다.");
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 레스토랑을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("즐겨찾기 해제 중 오류가 발생했습니다.");
         }
-
-        // 즐겨찾기 페이지로 리다이렉트
-        return "redirect:/mypage?favoritePage=" + favoritePage + "&favoriteSize=" + favoriteSize;
     }
+
 
     @GetMapping("/mypage")
     public String myPage(HttpSession session, Model model,
@@ -148,7 +155,7 @@ public class MemberController {
         List<Favorite> paginatedFavorites = favorites.subList(favoriteStart, favoriteEnd);
 
         // 프로필 이미지 URL 설정
-        String profileImageUrl = "https://i.kym-cdn.com/entries/icons/facebook/000/049/273/cover11.jpg";
+        String profileImageUrl = "https://via.placeholder.com/150";
         if (member.getProfileImage() != null) {
             profileImageUrl = ImagePathParser.parse(member.getProfileImage().getUuidFileName());
         }

--- a/src/main/resources/static/js/mypage.js
+++ b/src/main/resources/static/js/mypage.js
@@ -220,8 +220,7 @@ document.addEventListener('DOMContentLoaded', function() {
             e.preventDefault(); // 기본 폼 제출 동작을 방지합니다.
 
             const restaurantId = this.closest('form').querySelector('input[name="restaurantId"]').value;
-            const favoritePage = this.closest('form').querySelector('input[name="favoritePage"]').value;
-            const favoriteSize = this.closest('form').querySelector('input[name="favoriteSize"]').value;
+            const favoriteItem = this.closest('.favorite-item'); // 즐겨찾기 아이템 요소
 
             if (!restaurantId) {
                 alert('레스토랑 ID가 유효하지 않습니다.');
@@ -234,9 +233,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
                 body: new URLSearchParams({
-                    'restaurantId': restaurantId,
-                    'favoritePage': favoritePage,
-                    'favoriteSize': favoriteSize
+                    'restaurantId': restaurantId
                 })
             })
                 .then(response => {
@@ -248,7 +245,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 })
                 .then(text => {
                     alert('즐겨찾기가 해제되었습니다.');
-                    window.location.reload();
+                    favoriteItem.remove(); // UI에서 해당 아이템 제거
+
+                    // 모든 즐겨찾기 아이템이 제거된 경우 페이지 새로고침
+                    if (document.querySelectorAll('.favorite-item').length === 0) {
+                        window.location.reload(); // 페이지 새로고침
+                    }
                 })
                 .catch(error => {
                     console.error('Error:', error);

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -29,7 +29,7 @@
 
                 <a th:if="${isAuthenticated} and ${userRole == 'USER'}" href="/businessregister/register-store">입점 신청</a>
                 <a th:if="${isAuthenticated} and ${userRole == 'OWNER'}" href="/owner-dashboard">점주 페이지</a>
-                <a th:if="${isAuthenticated} and ${userRole == 'ADMIN'}" href="/admin/adminMain">관리자 페이지</a>
+                <a th:if="${isAuthenticated} and ${userRole == 'ADMIN'}" href="/adminMain">관리자 페이지</a>
             </nav>
         </div>
     </div>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -14,7 +14,7 @@
 <div th:replace="fragments/header :: header"></div>
 
 <div class="container">
-    <div th:replace="fragments/mypage_profileHeader :: profileHeader(${member.name}, ${member.createdAt}, ${reviews.size()}, ${profileImageUrl})"></div>
+    <div th:replace="fragments/mypage_profileHeader :: profileHeader(${member.name}, ${member.createdAt}, ${reviews.size()}, ${profileImageUrl != null ? profileImageUrl : 'https://via.placeholder.com/150'})"></div>
 
     <div class="content-wrapper">
         <div class="sidebar">
@@ -36,7 +36,7 @@
                     <div th:each="review : ${reviews}" class="review-item" th:attr="data-restaurant-id=${review.restaurant.id}">
                         <!-- 이미지 갤러리 -->
                         <div class="review-images">
-                            <img th:each="image : ${reviewImagesMap[review.id]}" th:src="${image}" alt="리뷰 이미지" class="restaurant-image">
+                            <img th:each="image : ${reviewImagesMap[review.id]}" th:src="${image != null ? image : 'https://via.placeholder.com/300x200'}" alt="리뷰 이미지" class="restaurant-image">
                         </div>
                         <!-- 리뷰 내용 -->
                         <div class="review-content">
@@ -91,7 +91,7 @@
                     </div>
                     <!-- 즐겨찾기가 있는 경우 -->
                     <div th:each="favorite : ${favorites}" class="favorite-item" th:attr="data-restaurant-id=${favorite.restaurant.id}">
-                        <img th:src="${favorite.restaurant.coverImage != null ? favorite.restaurant.coverImage.uuidFileName : 'https://i.kym-cdn.com/entries/icons/facebook/000/049/273/cover11.jpg'}" alt="레스토랑 이미지" class="restaurant-image">
+                        <img th:src="${favorite.restaurant.coverImage != null ? favorite.restaurant.coverImage.uuidFileName : 'https://via.placeholder.com/300x200'}" alt="레스토랑 이미지" class="restaurant-image">
                         <div class="favorite-content">
                             <form th:action="@{/mypage/remove-favorite}" method="post" class="remove-favorite-form">
                                 <input type="hidden" name="restaurantId" th:value="${favorite.restaurant.id}" />
@@ -145,10 +145,10 @@
             </section>
 
             <!-- 일반 회원 수정 모달 -->
-            <div th:if="${isSocialLogin == false}" th:insert="~{fragments/mypage_editProfileModal_basic :: editProfileModalBasic(${member}, ${profileImageUrl})}"></div>
+            <div th:if="${isSocialLogin == false}" th:insert="~{fragments/mypage_editProfileModal_basic :: editProfileModalBasic(${member}, ${profileImageUrl != null ? profileImageUrl : 'https://via.placeholder.com/150'})}"></div>
 
             <!-- 소셜 로그인 사용자 모달 -->
-            <div th:if="${isSocialLogin == true}" th:insert="~{fragments/mypage_editProfileModal_social :: editProfileModalSocial(${member}, ${profileImageUrl})}"></div>
+            <div th:if="${isSocialLogin == true}" th:insert="~{fragments/mypage_editProfileModal_social :: editProfileModalSocial(${member}, ${profileImageUrl != null ? profileImageUrl : 'https://via.placeholder.com/150'})}"></div>
 
         </div>
     </div>


### PR DESCRIPTION
-관리자페이지에 제대로 접근할수 있도록 해더를 수정하였습니다
-즐겨찾기 해제가 제대로 작동할수 있도록 비동기처리로 변경하였습니다. 즐겨찾기가 비게 되면 자동적으로 새로고침으로 넘어가게 바꿨습니다. -프로필 사진을 등록 안한 경우 플레이스홀더 기본페이지로 프로필사진이 설정되게 됩니다.