### PR TITLE
Fix/inquiry: 모달 초기화 및 이벤트 리스너 중복 등록 문제 해결

### DIFF
--- a/src/main/resources/static/js/owner-dashboard.js
+++ b/src/main/resources/static/js/owner-dashboard.js
@@ -52,9 +52,10 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 function initializeModals() {
-    const modals = document.querySelectorAll('.modal');
+    const modals = document.querySelectorAll('.modal:not(.initialized)');
     modals.forEach(modal => {
         new bootstrap.Modal(modal);
+        modal.classList.add('initialized');
     });
 }
 

--- a/src/main/resources/static/js/owner/inquiries.js
+++ b/src/main/resources/static/js/owner/inquiries.js
@@ -6,7 +6,8 @@ $(document).ready(function () {
     $(document).on('click', '#post-inquiry', clickInquiryPost);
     $(document).on('click', '#forward-inquiry', clickInquiryForward);
 
-    $('#saveReply').click(saveInquiryReply);
+    // 기존 이벤트 리스너 제거 후 새로 등록
+    $('#saveReply').off('click').on('click', saveInquiryReply);
 });
 
 // 문의 내역 전체 조회


### PR DESCRIPTION
# 모달 초기화 및 이벤트 리스너 중복 등록 문제 해결

## 변경 사항

### owner-dashboard.js
- 모달 초기화 중복 방지 로직 추가
  - 초기화된 모달에 'initialized' 클래스 추가
  - 미초기화 모달만 선택하여 초기화 수행

### owner/inquiries.js
- 문의 답변 저장 이벤트 리스너 중복 등록 방지
  - 기존 이벤트 리스너 제거 후 새로 등록

## 개선 효과
- 페이지 새로고침 시 발생하던 모달 초기화 중복 문제 해결
- 이벤트 리스너 중복 등록으로 인한 성능 저하 방지

## 테스트 방법
1. 오너 대시보드 페이지 접속
2. 페이지 새로고침 후 모달 작동 확인
3. 문의 답변 저장 기능 정상 작동 확인